### PR TITLE
Don't extract a subtree if that subtree does not have any required fields

### DIFF
--- a/BSC.Fhir.Mapping.Tests/Data/Demographics/DemographicsQuestionnaire.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/Demographics/DemographicsQuestionnaire.cs
@@ -248,7 +248,8 @@ public partial class Demographics
                       "definition": "RelatedPerson.id",
                       "text": "(internal use)",
                       "type": "string",
-                      "readOnly": true
+                      "readOnly": true,
+                      "required": true
                     },
                     {
                       "extension": [

--- a/BSC.Fhir.Mapping.Tests/Data/GeneralNote/GeneralNoteQuestionnaire.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/GeneralNote/GeneralNoteQuestionnaire.cs
@@ -482,6 +482,7 @@ public partial class GeneralNote
                                     Definition = "DocumentReference.content.attachment",
                                     Text = "Note",
                                     Type = Questionnaire.QuestionnaireItemType.Attachment,
+                                    Required = true,
                                     Extension =
                                     {
                                         new() { Url = "attachment-type", Value = new FhirString("Text") },
@@ -559,6 +560,7 @@ public partial class GeneralNote
                             Definition = "DocumentReference.id",
                             Text = "ImageId",
                             Type = Questionnaire.QuestionnaireItemType.String,
+                            Required = true,
                             Extension =
                             {
                                 new() { Url = QUESTIONNAIRE_HIDDEN_URL, Value = new FhirBoolean(true) },

--- a/BSC.Fhir.Mapping.Tests/Data/GeneralNote/GeneralNoteQuestionnaireResponse.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/GeneralNote/GeneralNoteQuestionnaireResponse.cs
@@ -1,10 +1,9 @@
 using System.Text;
 using Hl7.Fhir.Model;
-using Hl7.Fhir.Serialization;
 
 namespace BSC.Fhir.Mapping.Tests.Data;
 
-public partial class GeneralNote
+public static partial class GeneralNote
 {
     public static QuestionnaireResponse CreateQuestionnaireResponse(
         string compositionId,
@@ -12,73 +11,47 @@ public partial class GeneralNote
         IReadOnlyCollection<string> imageIds
     )
     {
-        QuestionnaireResponse response =
-            new()
+        var response = BaseResponse(compositionId).AddNote(noteId).AddImages(imageIds);
+
+        return response;
+    }
+
+    private static QuestionnaireResponse AddNote(this QuestionnaireResponse response, string noteId)
+    {
+        response.Item.Add(
+            new QuestionnaireResponse.ItemComponent
             {
+                LinkId = "note",
                 Item =
                 {
-                    new() { LinkId = "composition.id", Answer = { new() { Value = new FhirString(compositionId) } } },
-                    new() { LinkId = "composition.date", },
+                    new() { LinkId = "note.id", Answer = { new() { Value = new FhirString(noteId) } } },
                     new()
                     {
-                        LinkId = "composition.event",
+                        LinkId = "note.content",
                         Item =
                         {
                             new()
                             {
-                                LinkId = "composition.event.period",
-                                Item =
+                                LinkId = "note.content.attachment",
+                                Answer =
                                 {
-                                    new()
-                                    {
-                                        LinkId = "composition.event.period.start",
-                                        Answer = { new() { Value = new FhirDateTime("2023-10-29") } }
-                                    }
+                                    new() { Value = new Attachment { Data = Encoding.UTF8.GetBytes("Hello World") } }
                                 }
                             }
                         }
-                    },
-                    new()
-                    {
-                        LinkId = "procedureCode",
-                        Answer =
-                        {
-                            new()
-                            {
-                                Value = new Coding { System = "ProcedureCode", Code = "DEF002" }
-                            }
-                        }
-                    },
-                    new() { LinkId = "composition.extension" },
-                    new()
-                    {
-                        LinkId = "note",
-                        Item =
-                        {
-                            new() { LinkId = "note.id", Answer = { new() { Value = new FhirString(noteId) } } },
-                            new()
-                            {
-                                LinkId = "note.content",
-                                Item =
-                                {
-                                    new()
-                                    {
-                                        LinkId = "note.content.attachment",
-                                        Answer =
-                                        {
-                                            new()
-                                            {
-                                                Value = new Attachment { Data = Encoding.UTF8.GetBytes("Hello World") }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
+                    }
                 }
-            };
+            }
+        );
 
+        return response;
+    }
+
+    private static QuestionnaireResponse AddImages(
+        this QuestionnaireResponse response,
+        IReadOnlyCollection<string> imageIds
+    )
+    {
         response.Item.AddRange(
             imageIds.Select(
                 id =>
@@ -95,4 +68,45 @@ public partial class GeneralNote
 
         return response;
     }
+
+    private static QuestionnaireResponse BaseResponse(string compositionId) =>
+        new()
+        {
+            Item =
+            {
+                new() { LinkId = "composition.id", Answer = { new() { Value = new FhirString(compositionId) } } },
+                new() { LinkId = "composition.date", },
+                new()
+                {
+                    LinkId = "composition.event",
+                    Item =
+                    {
+                        new()
+                        {
+                            LinkId = "composition.event.period",
+                            Item =
+                            {
+                                new()
+                                {
+                                    LinkId = "composition.event.period.start",
+                                    Answer = { new() { Value = new FhirDateTime("2023-10-29") } }
+                                }
+                            }
+                        }
+                    }
+                },
+                new()
+                {
+                    LinkId = "procedureCode",
+                    Answer =
+                    {
+                        new()
+                        {
+                            Value = new Coding { System = "ProcedureCode", Code = "DEF002" }
+                        }
+                    }
+                },
+                new() { LinkId = "composition.extension" },
+            }
+        };
 }

--- a/BSC.Fhir.Mapping.Tests/Data/PartialUpdate/Questionnaire.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/PartialUpdate/Questionnaire.cs
@@ -57,12 +57,14 @@ public partial class PartialUpdate
                         {
                             LinkId = "givenName",
                             Definition = "Patient.name.given",
+                            Required=  true,
                             Type = Questionnaire.QuestionnaireItemType.String,
                         },
                         new()
                         {
                             LinkId = "familyName",
                             Definition = "Patient.name.family",
+                            Required = true,
                             Type = Questionnaire.QuestionnaireItemType.String,
                         },
                     }

--- a/BSC.Fhir.Mapping.Tests/ExtractorTests.cs
+++ b/BSC.Fhir.Mapping.Tests/ExtractorTests.cs
@@ -130,6 +130,39 @@ public class ExtractorTests
         };
     }
 
+    private static object[] GeneralNoteWithNoImagesTestCase()
+    {
+        var patientId = Guid.NewGuid().ToString();
+        var compositionId = Guid.NewGuid().ToString();
+        var userId = Guid.NewGuid().ToString();
+        var originalImageIds = Array.Empty<string>();
+        var newImageIds = Array.Empty<string>();
+        var noteId = Guid.NewGuid().ToString();
+        return new object[]
+        {
+            GeneralNote.CreateQuestionnaire(),
+            GeneralNote.CreateQuestionnaireResponse(compositionId, noteId, originalImageIds),
+            GeneralNote.ResourceLoaderResponse(compositionId, patientId, userId, newImageIds, noteId),
+            new Dictionary<string, StructureDefinition> { { "Composition", GeneralNote.CreateProfile() } },
+            new Dictionary<string, Resource>
+            {
+                {
+                    "user",
+                    new Practitioner { Id = userId }
+                },
+                {
+                    "patient",
+                    new Patient { Id = patientId }
+                },
+                {
+                    "composition",
+                    new Composition { Id = compositionId }
+                }
+            },
+            GeneralNote.ExtractionBundle(compositionId, patientId, userId, noteId, originalImageIds)
+        };
+    }
+
     private static object[][] PartialUpdateTestCase()
     {
         var patientId = Guid.NewGuid().ToString();
@@ -177,6 +210,7 @@ public class ExtractorTests
             ServiceRequestTestCase(),
             NewGeneralNoteTestCase(),
             UpdatedGeneralNoteTestCase(),
+            GeneralNoteWithNoImagesTestCase()
         }.Concat(PartialUpdateTestCase());
     }
 

--- a/BSC.Fhir.Mapping/Expressions/QuestionnaireParser.cs
+++ b/BSC.Fhir.Mapping/Expressions/QuestionnaireParser.cs
@@ -136,13 +136,6 @@ public class QuestionnaireParser
         var extensions = item.AllExtensions();
         ParseExtensions(extensions.ToArray(), item.LinkId);
 
-        if (responseItem.Answer.Count == 0 && item.Initial.Count > 0)
-        {
-            responseItem.Answer = item.Initial
-                .Select(initial => new QuestionnaireResponse.AnswerComponent { Value = initial.Value })
-                .ToList();
-        }
-
         ParseQuestionnaireItems(item.Item, responseItem.Item);
     }
 

--- a/BSC.Fhir.Mapping/Expressions/Scope.cs
+++ b/BSC.Fhir.Mapping/Expressions/Scope.cs
@@ -124,6 +124,14 @@ public class Scope : IClonable<Scope>
         scope.Context.AddRange(clonedContext);
     }
 
+    public bool HasRequiredAnswers()
+    {
+        var hasCalculated = Context.Any(ctx => ctx.Type == QuestionnaireContextType.CalculatedExpression);
+        var hasAnswers = Item?.Required == true && (ResponseItem?.Answer.Count > 0 || hasCalculated);
+
+        return hasAnswers || Children.Any(child => child.HasRequiredAnswers());
+    }
+
     public bool HasAnswers()
     {
         return ResponseItem?.Answer.Count > 0

--- a/BSC.Fhir.Mapping/Expressions/Scope.cs
+++ b/BSC.Fhir.Mapping/Expressions/Scope.cs
@@ -136,6 +136,7 @@ public class Scope : IClonable<Scope>
     public bool HasAnswers()
     {
         return ResponseItem?.Answer.Count > 0
+            || Item?.Initial.Count > 0
             || Context.Any(ctx => ctx.Type == QuestionnaireContextType.CalculatedExpression)
             || Children.Any(child => child.HasAnswers());
     }

--- a/BSC.Fhir.Mapping/Expressions/Scope.cs
+++ b/BSC.Fhir.Mapping/Expressions/Scope.cs
@@ -126,8 +126,9 @@ public class Scope : IClonable<Scope>
 
     public bool HasRequiredAnswers()
     {
-        var hasCalculated = Context.Any(ctx => ctx.Type == QuestionnaireContextType.CalculatedExpression);
-        var hasAnswers = Item?.Required == true && (ResponseItem?.Answer.Count > 0 || hasCalculated);
+        var hasCalculated =
+            Item?.Required == true && Context.Any(ctx => ctx.Type == QuestionnaireContextType.CalculatedExpression);
+        var hasAnswers = ResponseItem?.Answer.Count > 0 || hasCalculated;
 
         return hasAnswers || Children.Any(child => child.HasRequiredAnswers());
     }

--- a/BSC.Fhir.Mapping/Expressions/TreeDebugging.cs
+++ b/BSC.Fhir.Mapping/Expressions/TreeDebugging.cs
@@ -54,19 +54,6 @@ internal static class TreeDebugging
             }
         }
 
-        // str.AppendLine(prefix + "│");
-        // str.AppendLine(prefix + "├─ " + "ExtractionContext");
-        // var childPrefix = prefix + "│     ";
-        // str.AppendLine(childPrefix + "│");
-        // str.AppendLine(
-        //     childPrefix
-        //         + "└─ "
-        //         + (
-        //             scope.ExtractionContextValue() is ExtractionContext contextValue
-        //                 ? contextValue.Value.GetType()
-        //                 : "Nope"
-        //         )
-        // );
         str.AppendLine(prefix + "│");
         str.AppendLine(prefix + "├─ " + "HasRequiredAnswers");
         var childPrefix = prefix + "│     ";

--- a/BSC.Fhir.Mapping/Extractor.cs
+++ b/BSC.Fhir.Mapping/Extractor.cs
@@ -332,6 +332,10 @@ public class Extractor : IExtractor
         {
             answers = scope.ResponseItem.Answer.Select(answer => answer.Value).ToArray();
         }
+        else if (scope.Item.Initial.Count > 0)
+        {
+            answers = scope.Item.Initial.Select(initial => initial.Value).ToArray();
+        }
         else if (calculatedValue?.Value is not null)
         {
             answers = calculatedValue.Value.OfType<DataType>().ToArray();
@@ -889,7 +893,13 @@ public class Extractor : IExtractor
         QuestionnaireResponse.ItemComponent responseItem
     )
     {
-        var value = responseItem.Answer.First().Value;
+        var value = responseItem.Answer.FirstOrDefault()?.Value ?? item.Initial.FirstOrDefault()?.Value;
+
+        if (value is null)
+        {
+            return;
+        }
+
         var existing = extractionContext.GetExtension(item.Definition);
         if (existing is not null)
         {

--- a/BSC.Fhir.Mapping/Extractor.cs
+++ b/BSC.Fhir.Mapping/Extractor.cs
@@ -5,7 +5,6 @@ using BSC.Fhir.Mapping.Core;
 using BSC.Fhir.Mapping.Core.Expressions;
 using BSC.Fhir.Mapping.Expressions;
 using Hl7.Fhir.Model;
-using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Validation;
 using Microsoft.Extensions.Logging;
 using Task = System.Threading.Tasks.Task;
@@ -55,7 +54,7 @@ public class Extractor : IExtractor
             throw new InvalidOperationException("Could not extract resources");
         }
 
-        // TreeDebugging.PrintTree(rootScope);
+        // _logger.LogDebug(TreeDebugging.PrintTree(rootScope));
 
         return await ExtractByDefinition(rootScope, cancellationToken);
     }
@@ -137,6 +136,11 @@ public class Extractor : IExtractor
         CancellationToken cancellationToken = default
     )
     {
+        if (!scope.HasRequiredAnswers())
+        {
+            return;
+        }
+
         var context = scope.ExtractionContextValue()?.Value as Resource;
 
         if (context is null)


### PR DESCRIPTION
## What?

I've added a short circuit that skips creating resources from `ExtractionContext` if the scope that the context is on, and it's subtree of scopes, does not have any required answers or calculated expressions.

## Why?

Because the `ScopeCreator` is creating a scope tree that closely follows the structure of the `Questionnaire`, the tree includes scopes that don't have any answers. When the `Extractor` traverses the tree and finds a scope with a `ExtractionContext` on it, a new resource is created, regardless of whether the subtree of that scope actually has any answers that need to be extracted. This leads to empty resources being created.

## How?

The direction I think we should take is changing the semantics of the `required` field on a `Questionnaire.ItemComponent`. Instead of being purely used for form validation, we can use it to denote if a calculated expression should be resolved or not, depending on if there are scopes in the same subtree that have answers.

We need a way to differentiate fields that should be calculated only when other fields in the same subtree have answers, from fields that should always be calculated. The mechanism I have decided to use for this is the `required` field on the `Questionnaire.ItemComponent`. 

The implementation of this revolves around the adding of a `HasRequiredAnswers` method to the `Scope` class. This method recursively checks whether the scope or any children scopes have a field that has an answer, or a field with a `CalculatedExpression` on it and the presence of the `required` flag.

## Visuals

Below are visualisations of Scope trees. These trees would be contained within a larger tree.

The first one has a field with an answer in it (`relatedPerson.name`) and a `CalculatedExpression` (`relatedPerson.patient`):

![image](https://github.com/bscglobal/fhir-resource-mapping/assets/40057059/58a9bf97-4392-45c8-b48a-3c2729cae345)

The second one has an empty field (`relatedPerson.name`) and the same `CalculatedExpression` as above:

![image](https://github.com/bscglobal/fhir-resource-mapping/assets/40057059/b895e8ea-21e3-4491-bc90-5caf5bd1828e)

Before the changes, both of these scope trees would have resulted in a `RelatedPerson` resource being created. Now, because the `relatedPerson.name` field does not have an answer, and the `relatedPerson.patient` is not marked as `required`, no resource will be created.

## Concerns

1. Test cases need to be added for the inverse of this: if a calculated field is marked as required and no other scope in the subtree has an answer, the calculated field should still be extracted.
2. The fact that the same flag (`required`) is being used for multiple things might lead to confusion or unforeseen problems. 