### PR TITLE
Fix slice clearing lists

### DIFF
--- a/BSC.Fhir.Mapping.Tests/Data/Common/Context.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/Common/Context.cs
@@ -1,0 +1,11 @@
+namespace BSC.Fhir.Mapping.Tests.Data.Common;
+
+public record LaunchContext(string Name, string Type, string Display);
+
+public record FhirExpression(string Expression, string? Name, string? Language);
+
+public record FhirPathExpression(string Expression, string? Name = null)
+    : FhirExpression(Expression, Name, "text/fhirpath");
+
+public record FhirQueryExpression(string Expression, string? Name = null)
+    : FhirExpression(Expression, Name, "application/x-fhir-query");

--- a/BSC.Fhir.Mapping.Tests/Data/Common/QuestionnaireCreator.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/Common/QuestionnaireCreator.cs
@@ -1,0 +1,94 @@
+using BSC.Fhir.Mapping.Expressions;
+using Hl7.Fhir.Model;
+
+namespace BSC.Fhir.Mapping.Tests.Data.Common;
+
+public static class QuestionnaireCreator
+{
+    public static Questionnaire Create(
+        IEnumerable<LaunchContext> launchContext,
+        FhirExpression? extractionContext,
+        FhirExpression? populationContext,
+        IEnumerable<FhirExpression> variables,
+        IEnumerable<Questionnaire.ItemComponent> items
+    )
+    {
+        var questionnaire = new Questionnaire
+        {
+            Extension = launchContext
+                .Select(
+                    lc =>
+                        new Extension
+                        {
+                            Url = Constants.LAUNCH_CONTEXT,
+                            Extension =
+                            {
+                                new()
+                                {
+                                    Url = "name",
+                                    Value = new Coding
+                                    {
+                                        System = "http://hl7.org/fhir/uv/sdc/CodeSystem/launchContext",
+                                        Code = lc.Name,
+                                        Display = lc.Display
+                                    }
+                                },
+                                new() { Url = "type", Value = new Code(lc.Type) }
+                            }
+                        }
+                )
+                .ToList(),
+            Item = items.ToList()
+        };
+
+        if (extractionContext is not null)
+        {
+            questionnaire.Extension.Add(
+                new Extension
+                {
+                    Url = Constants.EXTRACTION_CONTEXT,
+                    Value = new Expression
+                    {
+                        Language = extractionContext.Language,
+                        Expression_ = extractionContext.Expression,
+                        Name = extractionContext.Name
+                    }
+                }
+            );
+        }
+
+        if (populationContext is not null)
+        {
+            questionnaire.Extension.Add(
+                new Extension
+                {
+                    Url = Constants.EXTRACTION_CONTEXT,
+                    Value = new Expression
+                    {
+                        Language = populationContext.Language,
+                        Expression_ = populationContext.Expression,
+                        Name = populationContext.Name
+                    }
+                }
+            );
+        }
+
+        questionnaire.Extension.AddRange(
+            variables.Select(
+                v =>
+                    new Extension
+                    {
+                        Url = Constants.VARIABLE_EXPRESSION,
+                        Value = new Expression
+                        {
+                            Language = v.Language,
+                            Expression_ = v.Expression,
+                            Name = v.Name
+                        }
+                    }
+            )
+        );
+
+        return questionnaire;
+    }
+}

--- a/BSC.Fhir.Mapping.Tests/Data/Common/QuestionnaireItemCreator.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/Common/QuestionnaireItemCreator.cs
@@ -1,0 +1,98 @@
+using BSC.Fhir.Mapping.Expressions;
+using Hl7.Fhir.Model;
+
+namespace BSC.Fhir.Mapping.Tests.Data.Common;
+
+public static class QuestionnaireItemCreator
+{
+    public static Questionnaire.ItemComponent Create(
+        string linkId,
+        string definition,
+        bool required,
+        bool readOnly,
+        bool hidden,
+        Questionnaire.QuestionnaireItemType type,
+        FhirExpression? extractionContext,
+        FhirExpression? populationContext,
+        FhirExpression? initialExpression,
+        IEnumerable<FhirExpression> variables,
+        IEnumerable<Questionnaire.ItemComponent> items
+    )
+    {
+        var item = new Questionnaire.ItemComponent
+        {
+            LinkId = linkId,
+            Definition = definition,
+            Required = required,
+            ReadOnly = readOnly,
+            Type = type,
+            Item = items.ToList()
+        };
+
+        if (extractionContext is not null)
+        {
+            item.Extension.Add(
+                new Extension
+                {
+                    Url = Constants.EXTRACTION_CONTEXT,
+                    Value = new Expression
+                    {
+                        Language = extractionContext.Language,
+                        Expression_ = extractionContext.Expression,
+                        Name = extractionContext.Name
+                    }
+                }
+            );
+        }
+
+        if (populationContext is not null)
+        {
+            item.Extension.Add(
+                new Extension
+                {
+                    Url = Constants.POPULATION_CONTEXT,
+                    Value = new Expression
+                    {
+                        Language = populationContext.Language,
+                        Expression_ = populationContext.Expression,
+                        Name = populationContext.Name
+                    }
+                }
+            );
+        }
+
+        if (initialExpression is not null)
+        {
+            item.Extension.Add(
+                new()
+                {
+                    Url = Constants.INITIAL_EXPRESSION,
+                    Value = new Expression
+                    {
+                        Language = initialExpression.Language,
+                        Expression_ = initialExpression.Expression,
+                        Name = initialExpression.Name
+                    }
+                }
+            );
+        }
+
+        item.Extension.AddRange(
+            variables.Select(
+                v =>
+                    new Extension
+                    {
+                        Url = Constants.VARIABLE_EXPRESSION,
+                        Value = new Expression
+                        {
+                            Language = v.Language,
+                            Expression_ = v.Expression,
+                            Name = v.Name
+                        }
+                    }
+            )
+        );
+
+        return item;
+    }
+}

--- a/BSC.Fhir.Mapping.Tests/Data/ExtractorTestCases/ExtractorTestCase.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/ExtractorTestCases/ExtractorTestCase.cs
@@ -1,0 +1,12 @@
+using Hl7.Fhir.Model;
+
+namespace BSC.Fhir.Mapping.Tests.Data.ExtractorTestCases;
+
+public abstract record ExtractorTestCase(
+    Questionnaire Questionnaire,
+    QuestionnaireResponse QuestionnaireResponse,
+    Dictionary<string, IReadOnlyCollection<Resource>> ResourceLoaderResponse,
+    Dictionary<string, StructureDefinition> Profiles,
+    Dictionary<string, Resource> LaunchContext,
+    Bundle ExpectedBundle
+);

--- a/BSC.Fhir.Mapping.Tests/Data/ExtractorTestCases/SimpleResourceCreate.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/ExtractorTestCases/SimpleResourceCreate.cs
@@ -1,0 +1,62 @@
+using BSC.Fhir.Mapping.Tests.Data.Common;
+using Hl7.Fhir.Model;
+
+namespace BSC.Fhir.Mapping.Tests.Data.ExtractorTestCases;
+
+public record SimpleResourceCreate()
+    : ExtractorTestCase(
+        CreateQuestionnaire(),
+        CreateQuestionnaireResponse(),
+        new(),
+        new(),
+        CreateLaunchContext(),
+        CreateExpectedBundle()
+    )
+{
+    private static Questionnaire CreateQuestionnaire()
+    {
+        return QuestionnaireCreator.Create(
+            new[] { new LaunchContext("patient", "Patient", "Patient") },
+            new FhirQueryExpression("Patient?_id={{%patient.id}}"),
+            null,
+            Array.Empty<FhirExpression>(),
+            new[]
+            {
+                QuestionnaireItemCreator.Create(
+                    "patientBirthDate",
+                    "Patient.birthDate",
+                    true,
+                    false,
+                    false,
+                    Questionnaire.QuestionnaireItemType.Date,
+                    null,
+                    null,
+                    null,
+                    Array.Empty<FhirExpression>(),
+                    Array.Empty<Questionnaire.ItemComponent>()
+                ),
+            }
+        );
+    }
+
+    private static QuestionnaireResponse CreateQuestionnaireResponse()
+    {
+        return new()
+        {
+            Item =
+            {
+                new() { LinkId = "patientBirthDate", Answer = { new() { Value = new Date("2021-01-01") } } }
+            }
+        };
+    }
+
+    private static Dictionary<string, Resource> CreateLaunchContext()
+    {
+        return new();
+    }
+
+    private static Bundle CreateExpectedBundle()
+    {
+        return new() { Entry = { new() { Resource = new Patient { BirthDateElement = new Date("2021-01-01") } } } };
+    }
+}

--- a/BSC.Fhir.Mapping.Tests/Data/GeneralNote/ExtractionBundle.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/GeneralNote/ExtractionBundle.cs
@@ -10,6 +10,7 @@ public partial class GeneralNote
         string patientId,
         string userId,
         string noteId,
+        string? noteText,
         IReadOnlyCollection<string> imageIds
     )
     {
@@ -53,7 +54,8 @@ public partial class GeneralNote
                                         }
                                     }
                                 },
-                                Entry = { new($"DocumentReference/{noteId}") }
+                                Entry = { new($"DocumentReference/{noteId}") },
+                                Text = string.IsNullOrEmpty(noteText) ? null : new(noteText)
                             },
                             new()
                             {

--- a/BSC.Fhir.Mapping.Tests/Data/GeneralNote/GeneralNoteQuestionnaire.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/GeneralNote/GeneralNoteQuestionnaire.cs
@@ -329,6 +329,16 @@ public partial class GeneralNote
                                 },
                                 new() { Url = "referenceType", Value = new FhirString("DocumentReference") }
                             }
+                        },
+                        new()
+                        {
+                            Definition = "Composition.section.text",
+                            LinkId = "noteSection.text",
+                            Type = Questionnaire.QuestionnaireItemType.Text,
+                            Extension =
+                            {
+                                new() { Url = QUESTIONNAIRE_HIDDEN_URL, Value = new FhirBoolean(true) },
+                            }
                         }
                     },
                 },

--- a/BSC.Fhir.Mapping.Tests/Data/GeneralNote/PopulationResponse.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/GeneralNote/PopulationResponse.cs
@@ -60,6 +60,7 @@ public partial class GeneralNote
                     {
                         new() { LinkId = "noteSection.title", Answer = { new() { Value = new FhirString("Note") } } },
                         new() { LinkId = "noteSection.entry" },
+                        new() { LinkId = "noteSection.text" },
                     }
                 },
                 new()

--- a/BSC.Fhir.Mapping.Tests/Data/GeneralNote/Resources.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/GeneralNote/Resources.cs
@@ -86,11 +86,24 @@ public partial class GeneralNote
                                 }
                             }
                         },
-                        Entry = { new($"DocumentReference/{noteId}") }
+                        Entry = { new($"DocumentReference/{noteId}") },
+                        Text = new("This is text that should not be overwritten")
                     },
                     new()
                     {
                         Title = "Image",
+                        Code = new()
+                        {
+                            Coding =
+                            {
+                                new()
+                                {
+                                    System = "https://1beat.care/fhir/coding-system",
+                                    Code = "54321",
+                                    Display = "Images"
+                                }
+                            }
+                        },
                         Entry = existingImageIds.Select(id => new ResourceReference($"DocumentReference/{id}")).ToList()
                     },
                 },

--- a/BSC.Fhir.Mapping.Tests/ExtractorTests.cs
+++ b/BSC.Fhir.Mapping.Tests/ExtractorTests.cs
@@ -91,7 +91,7 @@ public class ExtractorTests
                     new Patient { Id = patientId }
                 }
             },
-            GeneralNote.ExtractionBundle(compositionId, patientId, userId, noteId, imageIds)
+            GeneralNote.ExtractionBundle(compositionId, patientId, userId, noteId, null, imageIds)
         };
     }
 
@@ -126,7 +126,14 @@ public class ExtractorTests
                     new Composition { Id = compositionId }
                 }
             },
-            GeneralNote.ExtractionBundle(compositionId, patientId, userId, noteId, originalImageIds)
+            GeneralNote.ExtractionBundle(
+                compositionId,
+                patientId,
+                userId,
+                noteId,
+                "This is text that should not be overwritten",
+                originalImageIds
+            )
         };
     }
 
@@ -159,7 +166,14 @@ public class ExtractorTests
                     new Composition { Id = compositionId }
                 }
             },
-            GeneralNote.ExtractionBundle(compositionId, patientId, userId, noteId, originalImageIds)
+            GeneralNote.ExtractionBundle(
+                compositionId,
+                patientId,
+                userId,
+                noteId,
+                "This is text that should not be overwritten",
+                originalImageIds
+            )
         };
     }
 

--- a/BSC.Fhir.Mapping.Tests/ExtractorTests.cs
+++ b/BSC.Fhir.Mapping.Tests/ExtractorTests.cs
@@ -2,6 +2,7 @@ using BSC.Fhir.Mapping.Core;
 using BSC.Fhir.Mapping.Core.Expressions;
 using BSC.Fhir.Mapping.Expressions;
 using BSC.Fhir.Mapping.Tests.Data;
+using BSC.Fhir.Mapping.Tests.Data.ExtractorTestCases;
 using BSC.Fhir.Mapping.Tests.Mocks;
 using FluentAssertions;
 using FluentAssertions.Equivalency;
@@ -22,6 +23,19 @@ public class ExtractorTests
         _output = output;
     }
 
+    [Fact]
+    public async Task Extractor_SimpleResource()
+    {
+        var testCase = new SimpleResourceCreate();
+        await TestExtractor(
+            testCase.Questionnaire,
+            testCase.QuestionnaireResponse,
+            testCase.ResourceLoaderResponse,
+            testCase.Profiles,
+            testCase.LaunchContext,
+            testCase.ExpectedBundle
+        );
+    }
 
     [Fact]
     public async Task Extractor_DemographicsTestCase()

--- a/BSC.Fhir.Mapping/Core/SliceDefinition.cs
+++ b/BSC.Fhir.Mapping/Core/SliceDefinition.cs
@@ -8,7 +8,7 @@ public class SliceDefinition
     public class SliceFilter
     {
         public PropertyInfo PropertyInfo { get; set; }
-        public DataType Value { get; set; }
+        public Element Value { get; set; }
 
         public SliceFilter(PropertyInfo propertyInfo, DataType value)
         {


### PR DESCRIPTION
## What?
I updated the `Extractor` to stop clearing lists when extracting slices, and to stop overwriting existing fields.

## Why?
Before this, when slices were being extracted, it would clear the whole list the slice was a part of. This means that if, for example, there are multiple slices on a single field (e.g. `Composition.section`), and only one of the slices are updated, it would clear the field entirely and remove any other slices on that field.

## How?
I check for a value in the list that we are slicing that matches the slice criteria, and pass that along instead of always creating a new value and overwriting the existing content.

## Visuals
N/A

## Testing
I added a field in the general note test case to test this behaviour.

## Concerns
N/A