### PR TITLE
Create new resource during extraction if extraction context is a Code (ab#28421)

### DIFF
--- a/BSC.Fhir.Mapping.Tests/Expressions/QuestionnaireParserTests.cs
+++ b/BSC.Fhir.Mapping.Tests/Expressions/QuestionnaireParserTests.cs
@@ -143,8 +143,6 @@ public class QuestionnaireParserTests
 
         var scope = await parser.ParseQuestionnaireAsync();
 
-        _output.WriteLine(TreeDebugging.PrintTree(scope));
-
         scope.Should().NotBeNull();
         scope.Context.Should().HaveCount(1);
     }

--- a/BSC.Fhir.Mapping.Tests/Expressions/QuestionnaireParserTests.cs
+++ b/BSC.Fhir.Mapping.Tests/Expressions/QuestionnaireParserTests.cs
@@ -145,6 +145,10 @@ public class QuestionnaireParserTests
 
         scope.Should().NotBeNull();
         scope.Context.Should().HaveCount(1);
+
+        var context = scope.Context.First();
+        context.Should().BeOfType<QuestionnaireContext>();
+        context.Value.Should().BeEquivalentTo(new[] { new Patient() });
     }
 
     private Mock<IResourceLoader> ResourceLoaderMock(Dictionary<string, IReadOnlyCollection<Resource>> results)

--- a/BSC.Fhir.Mapping/Expressions/QuestionnaireContext.cs
+++ b/BSC.Fhir.Mapping/Expressions/QuestionnaireContext.cs
@@ -1,4 +1,3 @@
-using BSC.Fhir.Mapping.Core;
 using BSC.Fhir.Mapping.Core.Expressions;
 using Hl7.Fhir.Model;
 
@@ -6,25 +5,26 @@ namespace BSC.Fhir.Mapping.Expressions;
 
 using BaseList = IReadOnlyCollection<Base>;
 
-public class LaunchContext : IQuestionnaireContext<BaseList>
+public class QuestionnaireContext : IQuestionnaireContext<BaseList>
 {
     private readonly HashSet<IQuestionnaireExpression<BaseList>> _dependants =
         new(QuestionnaireContextComparer<BaseList>.Default);
 
-    public string Name { get; }
+    public string? Name { get; }
     public BaseList Value { get; }
     public int Id { get; }
     public Scope Scope { get; }
-    public QuestionnaireContextType Type => QuestionnaireContextType.LaunchContext;
+    public QuestionnaireContextType Type { get; }
 
     public IEnumerable<IQuestionnaireExpression<BaseList>> Dependants => _dependants.AsEnumerable();
 
-    public LaunchContext(int id, string name, Resource value, Scope scope)
+    public QuestionnaireContext(int id, string? name, Resource value, Scope scope, QuestionnaireContextType type)
     {
         Id = id;
         Name = name;
         Value = new[] { value };
         Scope = scope;
+        Type = type;
     }
 
     public bool Resolved()


### PR DESCRIPTION
## What?
I implemented a mechanism in the `QuestionnaireParser` that creates a new FHIR resource if a `Code` with a valid name of a resource is given as a `ExtractionContext`.

## Why?
There are scenarios in which we might want to always create a new resource, instead of querying whether a resource exists first.

## How?
I added a condition in the switch expression that checks which type of extension is being parsed. The condition checks whether the type of the `ExtractionContext` is a `Expression` or a `Code`. If it is a `Code`, it creates the resource of the specified type, and adds it as a `QuestionnaireContext` object to the current `Scope`. 

I renamed `LaunchContext` to `QuestionnaireContext` and gave it a constructor param for the type to make it more widely usable.

## Visuals
N/A

## Testing
I added a unit test to test the scenario of a `Code` being set as the `ExtractionContext` value.

## Concerns
N/A
