### PR TITLE
Fix field with required initial value in subtree not registering as required answer

### DIFF
--- a/BSC.Fhir.Mapping.Tests/Expressions/ScopeTests.cs
+++ b/BSC.Fhir.Mapping.Tests/Expressions/ScopeTests.cs
@@ -1,0 +1,187 @@
+using BSC.Fhir.Mapping.Core.Expressions;
+using BSC.Fhir.Mapping.Expressions;
+using FluentAssertions;
+using Hl7.Fhir.Model;
+
+namespace BSC.Fhir.Mapping.Tests.Expressions;
+
+public class ScopeTests
+{
+    [Fact]
+    public void HasRequiredAnswers_ReturnsTrue_WhenInitialAnswersArePresent_OnRequiredField()
+    {
+        // Arrange
+        var questionnaireItem = new Questionnaire.ItemComponent
+        {
+            LinkId = "1",
+            Item =
+            {
+                new()
+                {
+                    LinkId = "1.1",
+                    Required = true,
+                    Initial = { new Questionnaire.InitialComponent { Value = new FhirString("answer1") } }
+                }
+            }
+        };
+
+        var questionnaireResponseItem = new QuestionnaireResponse.ItemComponent
+        {
+            LinkId = "1",
+            Item = { new() { LinkId = "1.1", } }
+        };
+
+        var idProvider = new NumericIdProvider();
+
+        var parentScope = new Scope(new Questionnaire(), new QuestionnaireResponse(), idProvider);
+        var scope1 = new Scope(parentScope, questionnaireItem, questionnaireResponseItem, idProvider);
+        var scope1_1 = new Scope(scope1, questionnaireItem.Item[0], questionnaireResponseItem.Item[0], idProvider);
+
+        // Act
+        var result = scope1.HasRequiredAnswers();
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasRequiredAnswers_ReturnsFalse_WhenInitialAnswersArePresent_OnNonRequiredField()
+    {
+        // Arrange
+        var questionnaireItem = new Questionnaire.ItemComponent
+        {
+            LinkId = "1",
+            Item =
+            {
+                new()
+                {
+                    LinkId = "1.1",
+                    Required = false,
+                    Initial = { new Questionnaire.InitialComponent { Value = new FhirString("answer1") } }
+                }
+            }
+        };
+
+        var questionnaireResponseItem = new QuestionnaireResponse.ItemComponent
+        {
+            LinkId = "1",
+            Item = { new() { LinkId = "1.1", } }
+        };
+
+        var idProvider = new NumericIdProvider();
+
+        var parentScope = new Scope(new Questionnaire(), new QuestionnaireResponse(), idProvider);
+        var scope1 = new Scope(parentScope, questionnaireItem, questionnaireResponseItem, idProvider);
+        var scope1_1 = new Scope(scope1, questionnaireItem.Item[0], questionnaireResponseItem.Item[0], idProvider);
+
+        // Act
+        var result = scope1.HasRequiredAnswers();
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasRequiredAnswers_ReturnsTrue_WhenCalculatedExpressionIsPresent_OnRequiredField()
+    {
+        // Arrange
+        var questionnaireItem = new Questionnaire.ItemComponent
+        {
+            LinkId = "1",
+            Item =
+            {
+                new()
+                {
+                    LinkId = "1.1",
+                    Required = true,
+                    Extension =
+                    {
+                        new() { Url = Constants.CALCULATED_EXPRESSION, Value = new Expression() }
+                    }
+                }
+            }
+        };
+
+        var questionnaireResponseItem = new QuestionnaireResponse.ItemComponent
+        {
+            LinkId = "1",
+            Item = { new() { LinkId = "1.1", } }
+        };
+
+        var idProvider = new NumericIdProvider();
+
+        var parentScope = new Scope(new Questionnaire(), new QuestionnaireResponse(), idProvider);
+        var scope1 = new Scope(parentScope, questionnaireItem, questionnaireResponseItem, idProvider);
+        var scope1_1 = new Scope(scope1, questionnaireItem.Item[0], questionnaireResponseItem.Item[0], idProvider);
+        scope1_1.Context.Add(
+            new QuestionnaireExpression<IReadOnlyCollection<Base>>(
+                idProvider.GetId(),
+                null,
+                "",
+                "",
+                scope1_1,
+                QuestionnaireContextType.CalculatedExpression,
+                null,
+                null
+            )
+        );
+
+        // Act
+        var result = scope1.HasRequiredAnswers();
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasRequiredAnswers_ReturnsFalse_WhenCalculatedExpressionIsPresent_OnNonRequiredField()
+    {
+        // Arrange
+        var questionnaireItem = new Questionnaire.ItemComponent
+        {
+            LinkId = "1",
+            Item =
+            {
+                new()
+                {
+                    LinkId = "1.1",
+                    Required = false,
+                    Extension =
+                    {
+                        new() { Url = Constants.CALCULATED_EXPRESSION, Value = new Expression() }
+                    }
+                }
+            }
+        };
+
+        var questionnaireResponseItem = new QuestionnaireResponse.ItemComponent
+        {
+            LinkId = "1",
+            Item = { new() { LinkId = "1.1", } }
+        };
+
+        var idProvider = new NumericIdProvider();
+
+        var parentScope = new Scope(new Questionnaire(), new QuestionnaireResponse(), idProvider);
+        var scope1 = new Scope(parentScope, questionnaireItem, questionnaireResponseItem, idProvider);
+        var scope1_1 = new Scope(scope1, questionnaireItem.Item[0], questionnaireResponseItem.Item[0], idProvider);
+        scope1_1.Context.Add(
+            new QuestionnaireExpression<IReadOnlyCollection<Base>>(
+                idProvider.GetId(),
+                null,
+                "",
+                "",
+                scope1_1,
+                QuestionnaireContextType.CalculatedExpression,
+                null,
+                null
+            )
+        );
+
+        // Act
+        var result = scope1.HasRequiredAnswers();
+
+        // Assert
+        result.Should().BeFalse();
+    }
+}

--- a/BSC.Fhir.Mapping/Expressions/Scope.cs
+++ b/BSC.Fhir.Mapping/Expressions/Scope.cs
@@ -128,7 +128,9 @@ public class Scope : IClonable<Scope>
     {
         var hasCalculated =
             Item?.Required == true && Context.Any(ctx => ctx.Type == QuestionnaireContextType.CalculatedExpression);
-        var hasAnswers = ResponseItem?.Answer.Count > 0 || hasCalculated;
+        var hasInitial = Item?.Required == true && Item?.Initial.Count > 0;
+
+        var hasAnswers = ResponseItem?.Answer.Count > 0 || hasCalculated || hasInitial;
 
         return hasAnswers || Children.Any(child => child.HasRequiredAnswers());
     }


### PR DESCRIPTION
Fixes [AB#28656](https://dev.azure.com/bscglobal/Bara%20Digitisation%20-%20Phase%201%20(RI.1008)/_sprints/backlog/Bara%20Digitisation%20-%20Phase%201%20(RI.1008)%20Team/Bara%20Digitisation%20-%20Phase%201%20(RI.1008)/Iteration%2014?workitem=28657).

## What?
I added a condition to the check for if a subtree that has an `ExtractionContext` should actually create/update the resource that it is pointing to. The condition checks whether any `Questionnaire.ItemComponent` in the subtree is both `required` and has any values in the `Initial` field.

## Why?
The `Extractor` was not creating/updating resources if a field in the subtree had a required field with an initial value on it.

## How?
I added a condition in `Scope.HasRequiredAnswers` that checks whether the `Questionnaire.ItemComponent` on that scope has `Required` set to `true`, and has any values in the `Initial` field. 

## Visuals
N/A

## Testing
I added unit tests to check this case. 

## Concerns
N/A