### PR TITLE
Fix ab#28688. A field with multiple Codings will now populate to a single QuestionnaireResponseItem with multiple answers

### DIFF
--- a/BSC.Fhir.Mapping.Tests/Data/Common/QuestionnaireItemCreator.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/Common/QuestionnaireItemCreator.cs
@@ -8,15 +8,17 @@ public static class QuestionnaireItemCreator
     public static Questionnaire.ItemComponent Create(
         string linkId,
         string definition,
-        bool required,
-        bool readOnly,
-        bool hidden,
         Questionnaire.QuestionnaireItemType type,
-        FhirExpression? extractionContext,
-        FhirExpression? populationContext,
-        FhirExpression? initialExpression,
-        IEnumerable<FhirExpression> variables,
-        IEnumerable<Questionnaire.ItemComponent> items
+        bool required = false,
+        bool readOnly = false,
+        bool hidden = false,
+        bool repeats = false,
+        FhirExpression? extractionContext = null,
+        FhirExpression? populationContext = null,
+        FhirExpression? initialExpression = null,
+        IEnumerable<FhirExpression>? variables = null,
+        IEnumerable<Questionnaire.ItemComponent>? items = null,
+        string? answerValueSet = null
     )
     {
         var item = new Questionnaire.ItemComponent
@@ -25,8 +27,9 @@ public static class QuestionnaireItemCreator
             Definition = definition,
             Required = required,
             ReadOnly = readOnly,
+            Repeats = repeats,
             Type = type,
-            Item = items.ToList()
+            Item = items?.ToList() ?? new List<Questionnaire.ItemComponent>(),
         };
 
         if (extractionContext is not null)
@@ -77,18 +80,26 @@ public static class QuestionnaireItemCreator
             );
         }
 
-        item.Extension.AddRange(
-            variables.Select(v => new Extension
-            {
-                Url = Constants.VARIABLE_EXPRESSION,
-                Value = new Expression
+        if (variables is not null)
+        {
+            item.Extension.AddRange(
+                variables.Select(v => new Extension
                 {
-                    Language = v.Language,
-                    Expression_ = v.Expression,
-                    Name = v.Name
-                }
-            })
-        );
+                    Url = Constants.VARIABLE_EXPRESSION,
+                    Value = new Expression
+                    {
+                        Language = v.Language,
+                        Expression_ = v.Expression,
+                        Name = v.Name
+                    }
+                })
+            );
+        }
+
+        if (answerValueSet is not null)
+        {
+            item.AnswerValueSet = answerValueSet;
+        }
 
         return item;
     }

--- a/BSC.Fhir.Mapping.Tests/Data/ExtractorTestCases/SimpleResourceCreate.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/ExtractorTestCases/SimpleResourceCreate.cs
@@ -25,15 +25,8 @@ public record SimpleResourceCreate()
                 QuestionnaireItemCreator.Create(
                     "patientBirthDate",
                     "Patient.birthDate",
-                    true,
-                    false,
-                    false,
                     Questionnaire.QuestionnaireItemType.Date,
-                    null,
-                    null,
-                    null,
-                    Array.Empty<FhirExpression>(),
-                    Array.Empty<Questionnaire.ItemComponent>()
+                    true
                 ),
             }
         );

--- a/BSC.Fhir.Mapping/Expressions/QuestionnaireParser.cs
+++ b/BSC.Fhir.Mapping/Expressions/QuestionnaireParser.cs
@@ -681,7 +681,14 @@ public class QuestionnaireParser
                         .ToArray()
                 );
             }
-            else if (!fhirpathResult.First().GetType().IsSubclassOf(typeof(PrimitiveType)) && fhirpathResult.Count > 1)
+            else if (
+                fhirpathResult.First().GetType() is Type type
+                && !(
+                    type.IsSubclassOf(typeof(PrimitiveType))
+                    || (type.IsAssignableTo(typeof(Coding)) && query.QuestionnaireItem?.Item.Count == 0)
+                )
+                && fhirpathResult.Count > 1
+            )
             {
                 _logger.LogDebug("exploding {Expr}", query.Expression);
                 ExplodeExpression(fhirpathResult, new[] { query }, query.Scope, evalResult.SourceResourceType);

--- a/BSC.Fhir.Mapping/Populator.cs
+++ b/BSC.Fhir.Mapping/Populator.cs
@@ -43,6 +43,8 @@ public class Populator : IPopulator
             cancellationToken
         );
 
+        // _logger.LogDebug(TreeDebugging.PrintTree(rootScope));
+
         if (rootScope is null)
         {
             throw new InvalidOperationException("Could not populate QuestionnaireResponse");


### PR DESCRIPTION
## What?
I added behaviour that maps the result of an expression evaluation, if the evaluation type is `Coding`, to a list of results.

## Why?
A field with multiple `Coding`s (`CodeableConcept.coding`) would populate to multiple `QuestionnaireResponse.ItemComponent`s, even if the `Questionnaire` questionnaire does not have any children. This was unexpected behaviour, as the `Coding` fields are usually populated to a `Questionnaire.ItemComponent` that has a control on it.

## How?
Previously, if a `FhirPath` eval resulted in more than one value a new `Scope` would be created for each value in the list, unless the type of the result is a primitive value (`string`, `int`, etc.). `Coding` is now also included in those exceptions, if there are no children scopes (the `Questionnaire.ItemComponent.Item` list is empty). 

## Visuals
N/A

## Testing
I created a unit test for this case.

## Concerns
N/A