### PR TITLE
Handle calculated expressions pointing to Questionnaire.ItemComponent

### DIFF
--- a/BSC.Fhir.Mapping.Tests/Data/Common/QuestionnaireItemCreator.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/Common/QuestionnaireItemCreator.cs
@@ -7,8 +7,8 @@ public static class QuestionnaireItemCreator
 {
     public static Questionnaire.ItemComponent Create(
         string linkId,
-        string definition,
         Questionnaire.QuestionnaireItemType type,
+        string? definition = null,
         bool required = false,
         bool readOnly = false,
         bool hidden = false,
@@ -16,9 +16,12 @@ public static class QuestionnaireItemCreator
         FhirExpression? extractionContext = null,
         FhirExpression? populationContext = null,
         FhirExpression? initialExpression = null,
+        FhirExpression? calculatedExpression = null,
         IEnumerable<FhirExpression>? variables = null,
+        IEnumerable<DataType>? initial = null,
         IEnumerable<Questionnaire.ItemComponent>? items = null,
-        string? answerValueSet = null
+        string? answerValueSet = null,
+        IEnumerable<Extension>? extensions = null
     )
     {
         var item = new Questionnaire.ItemComponent
@@ -80,6 +83,22 @@ public static class QuestionnaireItemCreator
             );
         }
 
+        if (calculatedExpression is not null)
+        {
+            item.Extension.Add(
+                new()
+                {
+                    Url = Constants.CALCULATED_EXPRESSION,
+                    Value = new Expression
+                    {
+                        Language = calculatedExpression.Language,
+                        Expression_ = calculatedExpression.Expression,
+                        Name = calculatedExpression.Name
+                    }
+                }
+            );
+        }
+
         if (variables is not null)
         {
             item.Extension.AddRange(
@@ -96,9 +115,19 @@ public static class QuestionnaireItemCreator
             );
         }
 
+        if (initial is not null)
+        {
+            item.Initial = initial.Select(i => new Questionnaire.InitialComponent { Value = i }).ToList();
+        }
+
         if (answerValueSet is not null)
         {
             item.AnswerValueSet = answerValueSet;
+        }
+
+        if (extensions is not null)
+        {
+            item.Extension.AddRange(extensions);
         }
 
         return item;

--- a/BSC.Fhir.Mapping.Tests/Data/ExtractorTestCases/SimpleResourceCreate.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/ExtractorTestCases/SimpleResourceCreate.cs
@@ -24,8 +24,8 @@ public record SimpleResourceCreate()
             {
                 QuestionnaireItemCreator.Create(
                     "patientBirthDate",
-                    "Patient.birthDate",
                     Questionnaire.QuestionnaireItemType.Date,
+                    "Patient.birthDate",
                     true
                 ),
             }

--- a/BSC.Fhir.Mapping.Tests/Data/GeneralNote/GeneralNoteQuestionnaire.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/GeneralNote/GeneralNoteQuestionnaire.cs
@@ -18,7 +18,7 @@ public partial class GeneralNote
     private const string LAUNCH_CONTEXT_EXTENSION_URL =
         "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext";
 
-    public static Questionnaire CreateQuestionnaire()
+    public static Questionnaire CreateQuestionnaire(string? noteId = null)
     {
         var questionnaire = new Questionnaire
         {
@@ -417,7 +417,7 @@ public partial class GeneralNote
                             Text = "Note",
                             Type = Questionnaire.QuestionnaireItemType.String,
                             ReadOnly = true,
-                            Extension =
+                            Extension = new Extension[]
                             {
                                 new() { Url = QUESTIONNAIRE_HIDDEN_URL, Value = new FhirBoolean(true) },
                                 new()
@@ -426,6 +426,23 @@ public partial class GeneralNote
                                     Value = new Expression { Language = "text/fhirpath", Expression_ = "%popNote.id" }
                                 },
                             }
+                                .Concat(
+                                    noteId != null
+                                        ? new Extension[]
+                                        {
+                                            new()
+                                            {
+                                                Url = Constants.CALCULATED_EXPRESSION,
+                                                Value = new Expression
+                                                {
+                                                    Language = "text/fhirpath",
+                                                    Expression_ = $"'{noteId}'"
+                                                }
+                                            }
+                                        }
+                                        : Array.Empty<Extension>()
+                                )
+                                .ToList()
                         },
                         new()
                         {

--- a/BSC.Fhir.Mapping.Tests/Data/GeneralNote/GeneralNoteQuestionnaireResponse.cs
+++ b/BSC.Fhir.Mapping.Tests/Data/GeneralNote/GeneralNoteQuestionnaireResponse.cs
@@ -7,7 +7,7 @@ public static partial class GeneralNote
 {
     public static QuestionnaireResponse CreateQuestionnaireResponse(
         string compositionId,
-        string noteId,
+        string? noteId,
         IReadOnlyCollection<string> imageIds
     )
     {
@@ -16,15 +16,20 @@ public static partial class GeneralNote
         return response;
     }
 
-    private static QuestionnaireResponse AddNote(this QuestionnaireResponse response, string noteId)
+    private static QuestionnaireResponse AddNote(this QuestionnaireResponse response, string? noteId = null)
     {
+        var noteIdAnswer = new QuestionnaireResponse.ItemComponent { LinkId = "note.id" };
+        if (noteId != null)
+        {
+            noteIdAnswer.Answer.Add(new() { Value = new FhirString(noteId) });
+        }
         response.Item.Add(
             new QuestionnaireResponse.ItemComponent
             {
                 LinkId = "note",
                 Item =
                 {
-                    new() { LinkId = "note.id", Answer = { new() { Value = new FhirString(noteId) } } },
+                    noteIdAnswer,
                     new()
                     {
                         LinkId = "note.content",

--- a/BSC.Fhir.Mapping.Tests/Expressions/QuestionnaireParserTests.cs
+++ b/BSC.Fhir.Mapping.Tests/Expressions/QuestionnaireParserTests.cs
@@ -5,6 +5,7 @@ using BSC.Fhir.Mapping.Tests.Data.Common;
 using BSC.Fhir.Mapping.Tests.Mocks;
 using FluentAssertions;
 using Hl7.Fhir.Model;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit.Abstractions;
 using FhirPathExpression = BSC.Fhir.Mapping.Tests.Data.Common.FhirPathExpression;
@@ -91,6 +92,12 @@ public class QuestionnaireParserTests
             },
         };
 
+        var evaluator = new FhirPathMapping(new TestLogger<FhirPathMapping>(_output));
+        var loggerFactoryMock = new Mock<ILoggerFactory>();
+        loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>())).Returns(new TestLogger(_output));
+
+        var graphGenerator = new DependencyGraphGenerator(idProvider, evaluator, loggerFactoryMock.Object);
+
         var questionnaireResponse = new QuestionnaireResponse();
         var parser = new QuestionnaireParser(
             idProvider,
@@ -99,8 +106,9 @@ public class QuestionnaireParserTests
             launchContext,
             resourceLoader.Object,
             ResolvingContext.Population,
-            new FhirPathMapping(new TestLogger<FhirPathMapping>(_output)),
-            new TestLogger<QuestionnaireParser>(_output)
+            evaluator,
+            new TestLogger<QuestionnaireParser>(_output),
+            graphGenerator
         );
 
         await parser.ParseQuestionnaireAsync();
@@ -132,6 +140,13 @@ public class QuestionnaireParserTests
 
         var idProvider = new NumericIdProvider();
         var resourceLoaderMock = new Mock<IResourceLoader>();
+
+        var evaluator = new FhirPathMapping(new TestLogger<FhirPathMapping>(_output));
+        var loggerFactoryMock = new Mock<ILoggerFactory>();
+        loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>())).Returns(new TestLogger(_output));
+
+        var graphGenerator = new DependencyGraphGenerator(idProvider, evaluator, loggerFactoryMock.Object);
+
         var parser = new QuestionnaireParser(
             idProvider,
             questionnaire,
@@ -139,8 +154,9 @@ public class QuestionnaireParserTests
             new Dictionary<string, Resource>(),
             resourceLoaderMock.Object,
             ResolvingContext.Extraction,
-            new FhirPathMapping(new TestLogger<FhirPathMapping>(_output)),
-            new TestLogger<QuestionnaireParser>(_output)
+            evaluator,
+            new TestLogger<QuestionnaireParser>(_output),
+            graphGenerator
         );
 
         var scope = await parser.ParseQuestionnaireAsync();
@@ -177,6 +193,12 @@ public class QuestionnaireParserTests
                 }
             );
 
+        var evaluator = new FhirPathMapping(new TestLogger<FhirPathMapping>(_output));
+        var loggerFactoryMock = new Mock<ILoggerFactory>();
+        loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>())).Returns(new TestLogger(_output));
+
+        var graphGenerator = new DependencyGraphGenerator(idProvider, evaluator, loggerFactoryMock.Object);
+
         var parser = new QuestionnaireParser(
             idProvider,
             questionnaire,
@@ -184,8 +206,9 @@ public class QuestionnaireParserTests
             new Dictionary<string, Resource> { { "patient", launchPatient } },
             resourceLoaderMock.Object,
             ResolvingContext.Extraction,
-            new FhirPathMapping(new TestLogger<FhirPathMapping>(_output)),
-            new TestLogger<QuestionnaireParser>(_output)
+            evaluator,
+            new TestLogger<QuestionnaireParser>(_output),
+            graphGenerator
         );
 
         var scope = await parser.ParseQuestionnaireAsync();
@@ -235,6 +258,12 @@ public class QuestionnaireParserTests
                 }
             );
 
+        var evaluator = new FhirPathMapping(new TestLogger<FhirPathMapping>(_output));
+        var loggerFactoryMock = new Mock<ILoggerFactory>();
+        loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>())).Returns(new TestLogger(_output));
+
+        var graphGenerator = new DependencyGraphGenerator(idProvider, evaluator, loggerFactoryMock.Object);
+
         var parser = new QuestionnaireParser(
             idProvider,
             questionnaire,
@@ -242,8 +271,9 @@ public class QuestionnaireParserTests
             new Dictionary<string, Resource> { { "patient", launchPatient } },
             resourceLoaderMock.Object,
             ResolvingContext.Population,
-            new FhirPathMapping(new TestLogger<FhirPathMapping>(_output)),
-            new TestLogger<QuestionnaireParser>(_output)
+            evaluator,
+            new TestLogger<QuestionnaireParser>(_output),
+            graphGenerator
         );
 
         var scope = await parser.ParseQuestionnaireAsync();
@@ -302,6 +332,13 @@ public class QuestionnaireParserTests
                     { "Patient?_id=456", new[] { new Patient { Id = "456" } } }
                 }
             );
+
+        var evaluator = new FhirPathMapping(new TestLogger<FhirPathMapping>(_output));
+        var loggerFactoryMock = new Mock<ILoggerFactory>();
+        loggerFactoryMock.Setup(factory => factory.CreateLogger(It.IsAny<string>())).Returns(new TestLogger(_output));
+
+        var graphGenerator = new DependencyGraphGenerator(idProvider, evaluator, loggerFactoryMock.Object);
+
         var parser = new QuestionnaireParser(
             idProvider,
             questionnaire,
@@ -309,8 +346,9 @@ public class QuestionnaireParserTests
             new Dictionary<string, Resource> { { "composition", launchComposition } },
             resourceLoaderMock.Object,
             ResolvingContext.Extraction,
-            new FhirPathMapping(new TestLogger<FhirPathMapping>(_output)),
-            new TestLogger<QuestionnaireParser>(_output)
+            evaluator,
+            new TestLogger<QuestionnaireParser>(_output),
+            graphGenerator
         );
 
         var scope = await parser.ParseQuestionnaireAsync();

--- a/BSC.Fhir.Mapping/Core/IDependencyGraphGenerator.cs
+++ b/BSC.Fhir.Mapping/Core/IDependencyGraphGenerator.cs
@@ -1,0 +1,8 @@
+using BSC.Fhir.Mapping.Expressions;
+
+namespace BSC.Fhir.Mapping.Core.Expressions;
+
+public interface IDependencyGraphGenerator
+{
+    void Generate(Scope rootScope);
+}

--- a/BSC.Fhir.Mapping/Expressions/DependencyGraphGenerator.cs
+++ b/BSC.Fhir.Mapping/Expressions/DependencyGraphGenerator.cs
@@ -1,0 +1,354 @@
+using System.Text.RegularExpressions;
+using BSC.Fhir.Mapping.Core;
+using BSC.Fhir.Mapping.Core.Expressions;
+using Hl7.Fhir.Model;
+using Microsoft.Extensions.Logging;
+
+namespace BSC.Fhir.Mapping.Expressions;
+
+using BaseList = IReadOnlyCollection<Base>;
+
+public class DependencyGraphGenerator : IDependencyGraphGenerator
+{
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly INumericIdProvider _idProvider;
+    private readonly FhirPathMapping _fhirPathEvaluator;
+
+    public DependencyGraphGenerator(
+        INumericIdProvider idProvider,
+        FhirPathMapping fhirPathEvaluator,
+        ILoggerFactory loggerFactory
+    )
+    {
+        _idProvider = idProvider;
+        _fhirPathEvaluator = fhirPathEvaluator;
+        _loggerFactory = loggerFactory;
+    }
+
+    public void Generate(Scope rootScope)
+    {
+        var generator = new Generator(
+            rootScope,
+            _loggerFactory.CreateLogger<Generator>(),
+            _idProvider,
+            _fhirPathEvaluator
+        );
+        generator.CreateDependencyGraph(rootScope);
+
+        if (generator.IsCircularGraph(rootScope) is IQuestionnaireExpression<BaseList> faultyDep)
+        {
+            throw new InvalidOperationException($"Detected circular dependency {faultyDep.Expression}");
+        }
+    }
+
+    private class Generator
+    {
+        private readonly Scope _rootScope;
+        private readonly ILogger<Generator> _logger;
+        private readonly INumericIdProvider _idProvider;
+        private readonly HashSet<int> _visitedScopes = new();
+        private readonly FhirPathMapping _fhirPathEvaluator;
+
+        public Generator(
+            Scope rootScope,
+            ILogger<Generator> logger,
+            INumericIdProvider idProvider,
+            FhirPathMapping fhirPathEvaluator
+        )
+        {
+            _rootScope = rootScope;
+            _logger = logger;
+            _idProvider = idProvider;
+            _fhirPathEvaluator = fhirPathEvaluator;
+        }
+
+        public void CreateDependencyGraph(Scope scope)
+        {
+            if (!_visitedScopes.Add(scope.Id))
+            {
+                _logger.LogDebug("Already visited scope {LinkId}", scope.Item?.LinkId ?? "root");
+                return;
+            }
+
+            for (var i = 0; i < scope.Context.Count; i++)
+            {
+                var context = scope.Context[i];
+                if (context is not QuestionnaireExpression<BaseList> query)
+                {
+                    continue;
+                }
+
+                if (query.ExpressionLanguage == Constants.FHIR_QUERY_MIME)
+                {
+                    CalculateFhirQueryDependencies(scope, query);
+                }
+                else if (query is FhirPathExpression fhirpathExpr)
+                {
+                    CalculateFhirPathDependencies(scope, fhirpathExpr);
+                }
+            }
+
+            foreach (var child in scope.Children)
+            {
+                CreateDependencyGraph(child);
+            }
+        }
+
+        private void CalculateFhirQueryDependencies(Scope scope, QuestionnaireExpression<BaseList> query)
+        {
+            var expression = query.Expression;
+            var embeddedFhirpathRegex = @"\{\{(.*)\}\}";
+            var matches = Regex.Matches(expression, embeddedFhirpathRegex);
+
+            foreach (Match match in matches)
+            {
+                if (query.Name == "images")
+                {
+                    _logger.LogDebug("Match: {0}", match.Value);
+                }
+                var fhirpathExpression = match.Groups.Values.FirstOrDefault()?.Value;
+                if (string.IsNullOrEmpty(fhirpathExpression))
+                {
+                    _logger.LogWarning("Invalid embedded query {0}", match.Value);
+                    continue;
+                }
+
+                fhirpathExpression = Regex.Replace(fhirpathExpression, "[{}]", "");
+
+                var embeddedQuery = CreateFhirPathExpression(
+                    null,
+                    fhirpathExpression,
+                    QuestionnaireContextType.Embedded,
+                    scope,
+                    query
+                );
+                if (query.Name == "images")
+                {
+                    _logger.LogDebug(
+                        "Adding Embedded expression {Expression} ({Id}) to scope {LinkId}",
+                        embeddedQuery.Expression,
+                        embeddedQuery.Id,
+                        scope.Item?.LinkId ?? "root"
+                    );
+                }
+                scope.Context.Add(embeddedQuery);
+
+                query.AddDependency(embeddedQuery);
+            }
+        }
+
+        private void CalculateFhirPathDependencies(Scope scope, FhirPathExpression query)
+        {
+            // Regex for splitting fhirpath into respective parts, split by a period and including functions
+            var fhirpathRegex = @"([^.]+(\((.+\..+)+\)))?([^.]+)?";
+            var expression = query.Expression;
+
+            var parts = Regex.Matches(expression, fhirpathRegex).Select(match => match.Value);
+            var variables = parts.Where(part => part.StartsWith('%'));
+
+            foreach (var variable in variables)
+            {
+                if (Constants.RESPONSE_DEPENDANT_CONTEXT.Contains(variable))
+                {
+                    query.MakeResponseDependant();
+                    continue;
+                }
+
+                var varName = variable[1..];
+                var dep = scope.GetContext(varName);
+
+                if (dep is not null)
+                {
+                    query.AddDependency(dep);
+                }
+                else
+                {
+                    _logger.LogError(
+                        "Could not find dependency {VarName} in expression {Expression} for LinkId {LinkId}",
+                        varName,
+                        expression,
+                        query.QuestionnaireItem?.LinkId ?? "root"
+                    );
+                }
+            }
+
+            if (query.ResponseDependant)
+            {
+                var qItemExpr = Regex.Replace(expression, "%resource", "%questionnaire");
+                qItemExpr = Regex.Replace(qItemExpr, "%context", "%qitem");
+                var qitemExpr = (FhirPathExpression)query.Clone(new { Id = _idProvider.GetId(), Scope = scope, });
+
+                qitemExpr.ReplaceExpression(qItemExpr);
+                var result = _fhirPathEvaluator.EvaluateExpr(qitemExpr);
+
+                if (result is null || result.Result.FirstOrDefault() is not Questionnaire.ItemComponent qItem)
+                {
+                    _logger.LogWarning(
+                        "Response Dependant FHIRPath expression does not resolve to QuestionnaireItem: {Expr}",
+                        qItemExpr
+                    );
+                }
+                else
+                {
+                    _logger.LogDebug("Getting dependencies for expression {Expr}", query.Expression);
+                    var targetScope = ScopeTree.GetScope(qItem.LinkId, _rootScope);
+
+                    if (targetScope is null)
+                    {
+                        _logger.LogDebug("Could not find scope for LinkId {LinkId}", qItem.LinkId);
+                        return;
+                    }
+
+                    if (targetScope == scope)
+                    {
+                        _logger.LogDebug("Target scope is current scope");
+                        return;
+                    }
+
+                    var currentScopePath = scope.Path().ToArray();
+
+                    if (!currentScopePath.Contains(targetScope))
+                    {
+                        var targetScopePath = targetScope.Path().ToArray();
+
+                        var shortestPath = Math.Min(currentScopePath.Length, targetScopePath.Length);
+
+                        _logger.LogDebug(
+                            "Current Scope Path: [{Path}]",
+                            string.Join(", ", currentScopePath.Select(s => $"{s.Item?.LinkId ?? "root"} - {s.Id}"))
+                        );
+                        _logger.LogDebug(
+                            "Target Scope Path: [{Path}]",
+                            string.Join(", ", targetScopePath.Select(s => $"{s.Item?.LinkId ?? "root"} - {s.Id}"))
+                        );
+
+                        var targetRoot = targetScopePath.First();
+
+                        for (var i = 0; i < shortestPath; i++)
+                        {
+                            var scope1 = currentScopePath[i];
+                            var scope2 = targetScopePath[i];
+
+                            if (scope1 != scope2)
+                            {
+                                _logger.LogDebug(
+                                    "Found LCA scope: {LinkId} - {Id}",
+                                    targetRoot.Item?.LinkId ?? "root",
+                                    targetRoot.Id
+                                );
+                                targetRoot = scope2;
+                                break;
+                            }
+
+                            if (i == shortestPath - 1)
+                            {
+                                _logger.LogDebug(
+                                    "Found LCA scope: {LinkId} - {Id}",
+                                    scope1.Item?.LinkId ?? "root",
+                                    scope1.Id
+                                );
+                                targetRoot = targetScopePath[i + 1];
+                                break;
+                            }
+
+                            _logger.LogDebug(
+                                "Found common scope: {LinkId} - {Id}",
+                                scope1.Item?.LinkId ?? "root",
+                                scope1.Id
+                            );
+                            targetRoot = scope1;
+                        }
+
+                        CreateDependencyGraph(targetRoot);
+                    }
+
+                    _logger.LogDebug(
+                        "Context for Scope {LinkId} is [{Context}]",
+                        targetScope.Item?.LinkId ?? "root",
+                        string.Join(", ", targetScope.Context.Select(ctx => ctx.Type))
+                    );
+
+                    var initial =
+                        targetScope.Context.FirstOrDefault(ctx =>
+                            ctx.Type == QuestionnaireContextType.InitialExpression
+                            || ctx.Type == QuestionnaireContextType.CalculatedExpression
+                        ) as IQuestionnaireExpression<BaseList>;
+
+                    if (initial is not null)
+                    {
+                        _logger.LogDebug("Adding dependency '{0}' to '{1}'", initial.Expression, query.Expression);
+                        query.AddDependency(initial);
+                    }
+                }
+            }
+        }
+
+        public IQuestionnaireExpression<BaseList>? IsCircularGraph(Scope scope)
+        {
+            var checkedExprs = new HashSet<IQuestionnaireContext<BaseList>>();
+
+            foreach (var ctx in scope.Context.OfType<IQuestionnaireExpression<BaseList>>())
+            {
+                if (IsCircularGraph(ctx.Id, ctx) is IQuestionnaireExpression<BaseList> faultyDep)
+                {
+                    return faultyDep;
+                }
+            }
+
+            foreach (var child in scope.Children)
+            {
+                if (IsCircularGraph(child) is IQuestionnaireExpression<BaseList> faultyDep)
+                {
+                    return faultyDep;
+                }
+            }
+
+            return null;
+        }
+
+        private IQuestionnaireExpression<BaseList>? IsCircularGraph(
+            int originalId,
+            IQuestionnaireExpression<BaseList> expression
+        )
+        {
+            foreach (var dep in expression.Dependencies.OfType<IQuestionnaireExpression<BaseList>>())
+            {
+                if (originalId == dep.Id)
+                {
+                    return expression;
+                }
+
+                if (IsCircularGraph(originalId, dep) is IQuestionnaireExpression<BaseList> faultyDep)
+                {
+                    return faultyDep;
+                }
+            }
+
+            return null;
+        }
+
+        private FhirPathExpression CreateFhirPathExpression(
+            string? name,
+            string expr,
+            QuestionnaireContextType queryType,
+            Scope scope,
+            IQuestionnaireExpression<BaseList>? from = null
+        ) =>
+            new(
+                _idProvider.GetId(),
+                name,
+                expr,
+                scope,
+                queryType,
+                from is not null ? from.QuestionnaireItem : _rootScope.Item,
+                from is not null ? from.QuestionnaireResponseItem : _rootScope.ResponseItem
+            );
+
+        private FhirQueryExpression CreateFhirQueryExpression(
+            string? name,
+            string expr,
+            QuestionnaireContextType queryType,
+            Scope scope
+        ) => new(_idProvider.GetId(), name, expr, scope, queryType, _rootScope.Item, _rootScope.ResponseItem);
+    }
+}

--- a/BSC.Fhir.Mapping/Expressions/DependencyGraphGenerator.cs
+++ b/BSC.Fhir.Mapping/Expressions/DependencyGraphGenerator.cs
@@ -66,7 +66,6 @@ public class DependencyGraphGenerator : IDependencyGraphGenerator
         {
             if (!_visitedScopes.Add(scope.Id))
             {
-                _logger.LogDebug("Already visited scope {LinkId}", scope.Item?.LinkId ?? "root");
                 return;
             }
 
@@ -102,10 +101,6 @@ public class DependencyGraphGenerator : IDependencyGraphGenerator
 
             foreach (Match match in matches)
             {
-                if (query.Name == "images")
-                {
-                    _logger.LogDebug("Match: {0}", match.Value);
-                }
                 var fhirpathExpression = match.Groups.Values.FirstOrDefault()?.Value;
                 if (string.IsNullOrEmpty(fhirpathExpression))
                 {
@@ -122,15 +117,6 @@ public class DependencyGraphGenerator : IDependencyGraphGenerator
                     scope,
                     query
                 );
-                if (query.Name == "images")
-                {
-                    _logger.LogDebug(
-                        "Adding Embedded expression {Expression} ({Id}) to scope {LinkId}",
-                        embeddedQuery.Expression,
-                        embeddedQuery.Id,
-                        scope.Item?.LinkId ?? "root"
-                    );
-                }
                 scope.Context.Add(embeddedQuery);
 
                 query.AddDependency(embeddedQuery);
@@ -190,7 +176,6 @@ public class DependencyGraphGenerator : IDependencyGraphGenerator
                 }
                 else
                 {
-                    _logger.LogDebug("Getting dependencies for expression {Expr}", query.Expression);
                     var targetScope = ScopeTree.GetScope(qItem.LinkId, _rootScope);
 
                     if (targetScope is null)
@@ -251,22 +236,11 @@ public class DependencyGraphGenerator : IDependencyGraphGenerator
                                 break;
                             }
 
-                            _logger.LogDebug(
-                                "Found common scope: {LinkId} - {Id}",
-                                scope1.Item?.LinkId ?? "root",
-                                scope1.Id
-                            );
                             targetRoot = scope1;
                         }
 
                         CreateDependencyGraph(targetRoot);
                     }
-
-                    _logger.LogDebug(
-                        "Context for Scope {LinkId} is [{Context}]",
-                        targetScope.Item?.LinkId ?? "root",
-                        string.Join(", ", targetScope.Context.Select(ctx => ctx.Type))
-                    );
 
                     var initial =
                         targetScope.Context.FirstOrDefault(ctx =>
@@ -276,7 +250,6 @@ public class DependencyGraphGenerator : IDependencyGraphGenerator
 
                     if (initial is not null)
                     {
-                        _logger.LogDebug("Adding dependency '{0}' to '{1}'", initial.Expression, query.Expression);
                         query.AddDependency(initial);
                     }
                 }

--- a/BSC.Fhir.Mapping/Expressions/QuestionnaireParser.cs
+++ b/BSC.Fhir.Mapping/Expressions/QuestionnaireParser.cs
@@ -289,22 +289,6 @@ public class QuestionnaireParser
 
     private async Task<bool> ResolveDependenciesAsync(CancellationToken cancellationToken = default)
     {
-        var allExpressions = _scopeTree
-            .CurrentScope.AllContextInSubtree()
-            .OfType<IQuestionnaireExpression<BaseList>>()
-            .Where(expr =>
-                !expr.Resolved()
-                && !_notAllowedContextTypes.Contains(expr.Type)
-                && !expr.HasDependency(ctx => _notAllowedContextTypes.Contains(ctx.Type))
-            )
-            .ToArray();
-
-        var fhirPathExpressions = allExpressions.OfType<FhirPathExpression>().Select(expr => expr.Expression).ToArray();
-        var fhirQueryExpressions = allExpressions
-            .OfType<FhirQueryExpression>()
-            .Select(expr => expr.Expression)
-            .ToArray();
-
         while (true)
         {
             var expressions = _scopeTree

--- a/BSC.Fhir.Mapping/Expressions/Scope.cs
+++ b/BSC.Fhir.Mapping/Expressions/Scope.cs
@@ -8,6 +8,7 @@ using BaseList = IReadOnlyCollection<Base>;
 
 public class Scope : IClonable<Scope>
 {
+    public int Id { get; private set; }
     public int Level { get; }
     public Questionnaire Questionnaire { get; private init; }
     public QuestionnaireResponse QuestionnaireResponse { get; set; }
@@ -33,6 +34,7 @@ public class Scope : IClonable<Scope>
         Questionnaire = questionnaire;
         QuestionnaireResponse = questionnaireResponse;
         _idProvider = idProvider;
+        Id = _idProvider.GetId();
     }
 
     public Scope(
@@ -198,12 +200,23 @@ public class Scope : IClonable<Scope>
     {
         var context = GetContext(expr => expr.Resolved() && expr.Name == name, this);
 
-        if (name == "patientName")
+        return context is not null ? new(context) : null;
+    }
+
+    public IEnumerable<Scope> Path()
+    {
+        var path = new List<Scope> { this };
+        var parent = Parent;
+
+        while (parent is not null)
         {
-            Console.WriteLine("Debug: scope level - {0}", Level);
+            path.Add(parent);
+            parent = parent.Parent;
         }
 
-        return context is not null ? new(context) : null;
+        path.Reverse();
+
+        return path;
     }
 
     private static IQuestionnaireContext<BaseList>? GetContext(

--- a/BSC.Fhir.Mapping/Expressions/ScopeTreeCreator.cs
+++ b/BSC.Fhir.Mapping/Expressions/ScopeTreeCreator.cs
@@ -31,7 +31,8 @@ public class ScopeTreeCreator : IScopeTreeCreator
             _serviceProvider.GetRequiredService<IResourceLoader>(),
             context,
             _serviceProvider.GetRequiredService<FhirPathMapping>(),
-            _serviceProvider.GetRequiredService<ILogger<QuestionnaireParser>>()
+            _serviceProvider.GetRequiredService<ILogger<QuestionnaireParser>>(),
+            _serviceProvider.GetRequiredService<IDependencyGraphGenerator>()
         );
 
         return await parser.ParseQuestionnaireAsync(cancellationToken);

--- a/BSC.Fhir.Mapping/Expressions/TreeDebugging.cs
+++ b/BSC.Fhir.Mapping/Expressions/TreeDebugging.cs
@@ -118,6 +118,11 @@ internal static class TreeDebugging
         prefix = prefix + (addBar ? "│" : " ") + (addIndent ? "     " : "");
 
         str.AppendLine(prefix + "│");
+        str.AppendLine(prefix + "├─ Type");
+        str.AppendLine(prefix + "│     │");
+        str.AppendLine(prefix + "│     └─ " + context.Type.ToString());
+
+        str.AppendLine(prefix + "│");
         str.AppendLine(prefix + "├─ Resolved");
         str.AppendLine(prefix + "│     │");
         str.AppendLine(

--- a/BSC.Fhir.Mapping/FhirPathMapping.cs
+++ b/BSC.Fhir.Mapping/FhirPathMapping.cs
@@ -4,7 +4,6 @@ using BSC.Fhir.Mapping.Expressions;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
-using Hl7.Fhir.Serialization;
 using Hl7.FhirPath;
 using Hl7.FhirPath.Expressions;
 using Microsoft.Extensions.Logging;
@@ -124,7 +123,7 @@ public class FhirPathMapping
         return new(expr, new[] { scope.QuestionnaireResponse });
     }
 
-    private static EvaluationContext QuestionnaireEvaluationSource(string[] exprParts, Scope scope)
+    private EvaluationContext QuestionnaireEvaluationSource(string[] exprParts, Scope scope)
     {
         exprParts[0] = "%resource";
         var execExpr = string.Join('.', exprParts);

--- a/BSC.Fhir.Mapping/ServiceCollectionExtensions.cs
+++ b/BSC.Fhir.Mapping/ServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+using BSC.Fhir.Mapping.Core;
+using BSC.Fhir.Mapping.Core.Expressions;
+using BSC.Fhir.Mapping.Expressions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BSC.Fhir.Mapping;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddSdcMapping<T1, T2>(this IServiceCollection services)
+        where T1 : class, IProfileLoader
+        where T2 : class, IResourceLoader =>
+        services
+            .AddScoped<IProfileLoader, T1>()
+            .AddScoped<IResourceLoader, T2>()
+            .AddScoped<IExtractor, Extractor>()
+            .AddScoped<IPopulator, Populator>()
+            .AddScoped<IDependencyGraphGenerator, DependencyGraphGenerator>()
+            .AddScoped<IScopeTreeCreator, ScopeTreeCreator>()
+            .AddScoped<FhirPathMapping>()
+            .AddScoped<INumericIdProvider, NumericIdProvider>();
+}


### PR DESCRIPTION
[AB#29070](https://dev.azure.com/bscglobal/558244c9-8d5e-41b2-a55c-c99373d89ed2/_workitems/edit/29070), [AB#29211](https://dev.azure.com/bscglobal/558244c9-8d5e-41b2-a55c-c99373d89ed2/_workitems/edit/29211) 

## What?
I updated the `QuestionnaireParser` to handle `CalculatedExpressions` that resolve to a `Questionnaire` or `QuestionnaireResponse` item. While doing this, I discovered a bug that caused some of these expressions not to be resolved correctly.

## Why?
We need to be able to be able to set a answer in a `QuestionnaireResponse` to the value of another answer in that `QuestionnaireResponse`. What complicates this is that if that second answer needs to be filled in by another expression (`InitialExpression` or `CalculatedExpression`). Previously, we were only checking for `InitialExpressions`. 

## How?
Seems like a simple enough change. While implementing it, I realised that some of these dependency chains were not being resolved correctly. The logic that connects all of the expressions into a graph was assuming that whatever `Questionnaire.ItemComponent` the expression was pointing to, had already been connected to the dependency graph. I updated the implementation to make sure that the the dependent node has its dependencies calculated before adding it as a dependent to the expression pointing to the `Questionnaire.ItemComponent`.

I split out the logic for creating the dependency graph into a new `DependencyGraphGenerator` class.

## Visuals
N/A

## Testing
I added unit tests for the new test case (`CalculatedExpression` pointing to a `Questionnaire.ItemComponent` with a `CalculatedExpression` on it in turn). I also fixed the unit tests to use the new `DependencyGraphGenerator` class

## Concerns
- The `DependencyGraphGenerator` class needs unit tests.
